### PR TITLE
Fixed bug where CommandConvert will exit the programme when incorrect…

### DIFF
--- a/src/main/java/executor/command/CommandConvert.java
+++ b/src/main/java/executor/command/CommandConvert.java
@@ -47,7 +47,7 @@ public class CommandConvert extends Command {
             convertedAmount = this.convertCurrency(this.getFrom(), this.getTo(), this.getAmount());
             outputStr = this.getPrintableResult(convertedAmount);
         } catch (DukeException e) {
-            this.infoCapsule.setCodeExit();
+            this.infoCapsule.setCodeError();
             this.infoCapsule.setOutputStr(e.getMessage());
             return;
         }


### PR DESCRIPTION
… input was entered.

Error was in the catch block of the command. InfoCapsule was returning UiCode.Exit instead of UiCode.Error

Resolves Issue #238 
Signed-off-by: Mudaafi <SleepyUndergrad@gmail.com>