### PR TITLE
New feature that shows major expenses in the wallet

### DIFF
--- a/savedTask.txt
+++ b/savedTask.txt
@@ -1,2 +1,1 @@
 TODO test ####false
-TODO add ####false

--- a/savedWallet.txt
+++ b/savedWallet.txt
@@ -1,3 +1,4 @@
-
 0.0
-
+out $2.0 /date 2019-02-01 /tags food
+out $3.0 /date 2019-02-02 /tags transport
+out $65.0 /date 2019-02-01 /tags food

--- a/savedWallet.txt
+++ b/savedWallet.txt
@@ -1,7 +1,6 @@
 0.0
 out $2.0 /date 2019-02-01 /tags food
 out $3.0 /date 2019-02-02 /tags transport
-out $65.0 /date 2019-02-01 /tags food
 out $130.0 /date 2019-03-02 /tags transport
 out $100.5 /date 2019-02-03 /tags food
 out $100.0 /date 2019-09-04 /tags transport

--- a/savedWallet.txt
+++ b/savedWallet.txt
@@ -2,3 +2,6 @@
 out $2.0 /date 2019-02-01 /tags food
 out $3.0 /date 2019-02-02 /tags transport
 out $65.0 /date 2019-02-01 /tags food
+out $130.0 /date 2019-03-02 /tags transport
+out $100.5 /date 2019-02-03 /tags food
+out $100.0 /date 2019-09-04 /tags transport

--- a/src/main/java/executor/command/CommandMajorExpense.java
+++ b/src/main/java/executor/command/CommandMajorExpense.java
@@ -18,33 +18,49 @@ public class CommandMajorExpense extends Command {
         super();
         this.userInput = userInput;
         this.description = "Lists all major expense receipts higher than user cash input \n"
-                + "FORMAT : majorexpense <integer cash input>";
+                + "FORMAT : majorexpense <positive integer cash input>"
+                + " "
+                + "Lists all major expenses above/equal to $100\n"
+                + "FORMAT : majorexpense";
         this.commandType = CommandType.MAJOREXPENSE;
         this.amount = Parser.parseForPrimaryInput(this.commandType, userInput);
     }
 
     @Override
     public void execute(StorageManager storageManager) {
-        String outputStr = "These are your expenditures above/equal to" + " " + "$" + amount + "\n";
+        String outputStr = "These are your receipts above/equal to" + " " + "$" + amount + "\n";
+        String output = "These are your receipts above/equal to $" + 100 + "\n";
         if (amount.startsWith("-")) {
             this.infoCapsule.setCodeError();
             this.infoCapsule.setOutputStr("Input integer must be positive");
             return;
         }
-        try {
-            outputStr += storageManager.getMajorExpense(amount);
+        if (amount.isEmpty()) {
+            try {
+                output += storageManager.getMajorReceipt();
+            } catch (DukeException e) {
+                this.infoCapsule.setCodeError();
+                this.infoCapsule.setOutputStr(e.getMessage());
+                return;
+            }
+            this.infoCapsule.setCodeCli();
+            this.infoCapsule.setOutputStr(output);
+        } else {
+            try {
+                outputStr += storageManager.getMajorExpense(amount);
 
-        } catch (DukeException e) {
-            this.infoCapsule.setCodeError();
-            this.infoCapsule.setOutputStr(e.getMessage());
-            return;
-        } catch (NumberFormatException e) {
-            this.infoCapsule.setCodeError();
-            this.infoCapsule.setOutputStr("Invalid cash input. Please enter integer");
-            return;
+            } catch (DukeException e) {
+                this.infoCapsule.setCodeError();
+                this.infoCapsule.setOutputStr(e.getMessage());
+                return;
+            } catch (NumberFormatException e) {
+                this.infoCapsule.setCodeError();
+                this.infoCapsule.setOutputStr("Invalid cash input. Please enter integer");
+                return;
+            }
+            this.infoCapsule.setCodeCli();
+            this.infoCapsule.setOutputStr(outputStr);
         }
-        this.infoCapsule.setCodeCli();
-        this.infoCapsule.setOutputStr(outputStr);
     }
 }
 

--- a/src/main/java/executor/command/CommandMajorExpense.java
+++ b/src/main/java/executor/command/CommandMajorExpense.java
@@ -6,7 +6,6 @@ import storage.StorageManager;
 
 
 public class CommandMajorExpense extends Command {
-    protected String userInput;
     private String amount;
 
     /**
@@ -48,14 +47,9 @@ public class CommandMajorExpense extends Command {
         } else {
             try {
                 outputStr += storageManager.getMajorExpense(amount);
-
             } catch (DukeException e) {
                 this.infoCapsule.setCodeError();
                 this.infoCapsule.setOutputStr(e.getMessage());
-                return;
-            } catch (NumberFormatException e) {
-                this.infoCapsule.setCodeError();
-                this.infoCapsule.setOutputStr("Invalid cash input. Please enter integer");
                 return;
             }
             this.infoCapsule.setCodeCli();

--- a/src/main/java/executor/command/CommandMajorExpense.java
+++ b/src/main/java/executor/command/CommandMajorExpense.java
@@ -1,0 +1,50 @@
+package executor.command;
+
+import duke.exception.DukeException;
+import interpreter.Parser;
+import storage.StorageManager;
+
+
+public class CommandMajorExpense extends Command {
+    protected String userInput;
+    private String amount;
+
+    /**
+     * Constructor for CommandMajorExpense subCommand Class.
+     *
+     * @param userInput The user input from the CLI
+     */
+    public CommandMajorExpense(String userInput) {
+        super();
+        this.userInput = userInput;
+        this.description = "Lists all major expense receipts higher than user cash input \n"
+                + "FORMAT : majorexpense <integer cash input>";
+        this.commandType = CommandType.MAJOREXPENSE;
+        this.amount = Parser.parseForPrimaryInput(this.commandType, userInput);
+    }
+
+    @Override
+    public void execute(StorageManager storageManager) {
+        String outputStr = "These are your expenditures above/equal to" + " " + "$" + amount + "\n";
+        if (amount.startsWith("-")) {
+            this.infoCapsule.setCodeError();
+            this.infoCapsule.setOutputStr("Input integer must be positive");
+            return;
+        }
+        try {
+            outputStr += storageManager.getMajorExpense(amount);
+
+        } catch (DukeException e) {
+            this.infoCapsule.setCodeError();
+            this.infoCapsule.setOutputStr(e.getMessage());
+            return;
+        } catch (NumberFormatException e) {
+            this.infoCapsule.setCodeError();
+            this.infoCapsule.setOutputStr("Invalid cash input. Please enter integer");
+            return;
+        }
+        this.infoCapsule.setCodeCli();
+        this.infoCapsule.setOutputStr(outputStr);
+    }
+}
+

--- a/src/main/java/executor/command/CommandType.java
+++ b/src/main/java/executor/command/CommandType.java
@@ -9,6 +9,7 @@ public enum CommandType {
     DELETE(CommandDelete.class),
     DELETERECEIPT(CommandDeleteReceipt.class),
     DONE(CommandMarkDone.class),
+    MAJOREXPENSE(CommandMajorExpense.class),
     QUEUE(CommandQueue.class),
     VIEWSCHEDULE(CommandSchedule.class),
     REMINDER(CommandReminder.class),

--- a/src/main/java/storage/StorageManager.java
+++ b/src/main/java/storage/StorageManager.java
@@ -145,6 +145,8 @@ public class StorageManager {
     public String getMajorExpense(String amount) throws DukeException {
         try {
             return this.wallet.getReceipts().getMajorExpenses(amount).getPrintableReceipts();
+        } catch (NumberFormatException e) {
+            throw new DukeException("Invalid cash input. Please enter integer");
         } catch (Exception e) {
             throw new DukeException("Unable to get major expenses");
         }

--- a/src/main/java/storage/StorageManager.java
+++ b/src/main/java/storage/StorageManager.java
@@ -144,9 +144,23 @@ public class StorageManager {
      */
     public String getMajorExpense(String amount) throws DukeException {
         try {
-            return this.wallet.getReceipts().getmajorExpense(amount).getPrintableReceipts();
+            return this.wallet.getReceipts().getMajorExpenses(amount).getPrintableReceipts();
         } catch (Exception e) {
             throw new DukeException("Unable to get major expenses");
+        }
+    }
+
+    /**
+     * Gets all receipts that have cash spent attribute more than or equal to $100.
+     * Used by CommandMajorExpense
+     * @return ReceiptTracker containing all the receipts above or equal to $100
+     * @throws DukeException Error occurred when getting major expenses
+     */
+    public String getMajorReceipt() throws DukeException {
+        try {
+            return this.wallet.getReceipts().getMajorReceipts().getPrintableReceipts();
+        } catch (Exception e) {
+            throw new DukeException("Unable to get major receipt");
         }
     }
 

--- a/src/main/java/storage/StorageManager.java
+++ b/src/main/java/storage/StorageManager.java
@@ -136,6 +136,21 @@ public class StorageManager {
     }
 
     /**
+     * Gets all receipts that have cash spent attribute more than or equal to user input.
+     * Used by CommandMajorExpense
+     * @param amount String that represents the user input
+     * @return ReceiptTracker containing all the major expense receipts
+     * @throws DukeException Error occurred when getting major expenses
+     */
+    public String getMajorExpense(String amount) throws DukeException {
+        try {
+            return this.wallet.getReceipts().getmajorExpense(amount).getPrintableReceipts();
+        } catch (Exception e) {
+            throw new DukeException("Unable to get major expenses");
+        }
+    }
+
+    /**
      * Deletes Task by Index in TaskList Object.
      * Used in CommandDelete.
      * @param index int of Task to be deleted

--- a/src/main/java/ui/ReceiptTracker.java
+++ b/src/main/java/ui/ReceiptTracker.java
@@ -92,6 +92,22 @@ public class ReceiptTracker extends ArrayList<Receipt> {
     }
 
     /**
+     * Find all the expenses more than or equal to the cash input.
+     * @param amount Specific String to be filtered with.
+     * @return ArrayList containing all the Receipts with all the major expenses
+     */
+    public ReceiptTracker getmajorExpense(String amount) {
+        int input = Integer.parseInt(amount);
+        ReceiptTracker expenseReceipts = new ReceiptTracker();
+        for (Receipt receipt : this) {
+            if (receipt.getCashSpent() >= input) {
+                expenseReceipts.addReceipt(receipt);
+            }
+        }
+        return expenseReceipts;
+    }
+
+    /**
      * Find all receipts that corresponds to the specific date.
      * @param date Specific String to be filtered with
      * @return ArrayList containing all the Receipts with the specific date

--- a/src/main/java/ui/ReceiptTracker.java
+++ b/src/main/java/ui/ReceiptTracker.java
@@ -96,7 +96,7 @@ public class ReceiptTracker extends ArrayList<Receipt> {
      * @param amount Specific String to be filtered with.
      * @return ArrayList containing all the Receipts with all the major expenses
      */
-    public ReceiptTracker getmajorExpense(String amount) {
+    public ReceiptTracker getMajorExpenses(String amount) {
         int input = Integer.parseInt(amount);
         ReceiptTracker expenseReceipts = new ReceiptTracker();
         for (Receipt receipt : this) {
@@ -105,6 +105,21 @@ public class ReceiptTracker extends ArrayList<Receipt> {
             }
         }
         return expenseReceipts;
+    }
+
+    /**
+     * Find all the expenses more than or equal to $100.
+     *
+     * @return ArrayList containing all the receipts with expenses above/equal to $100
+     */
+    public ReceiptTracker getMajorReceipts() {
+        ReceiptTracker receipts = new ReceiptTracker();
+        for (Receipt receipt : this) {
+            if (receipt.getCashSpent() >= 100) {
+                receipts.addReceipt(receipt);
+            }
+        }
+        return receipts;
     }
 
     /**

--- a/src/test/java/CommandMajorExpenseTest.java
+++ b/src/test/java/CommandMajorExpenseTest.java
@@ -22,15 +22,28 @@ public class CommandMajorExpenseTest {
         receiptTwo.setDate(LocalDate.parse("2019-02-02"));
         storageManager.getWallet().addReceipt(receiptTwo);
 
+        Receipt receiptThree = new Receipt(100.0);
+        receiptThree.addTag("transport");
+        receiptThree.setDate(LocalDate.parse("2019-05-02"));
+        storageManager.getWallet().addReceipt(receiptThree);
+
 
         CommandMajorExpense m1 = new CommandMajorExpense("majorexpense 40");
         m1.execute(storageManager);
         String output = m1.getInfoCapsule().getOutputStr();
-        assertEquals("These are your expenditures above/equal to" + " " + "$" + 40 + "\n"
-                + "1. [transport] 40.0 2019-02-01\n", output);
+        assertEquals("These are your receipts above/equal to" + " " + "$" + 40 + "\n"
+                + "1. [transport] 40.0 2019-02-01\n"
+                + "2. [transport] 100.0 2019-05-02\n", output);
+
         CommandMajorExpense m2 = new CommandMajorExpense("majorexpense -5.0");
         m2.execute(storageManager);
         String result = m2.getInfoCapsule().getOutputStr();
         assertEquals("Input integer must be positive", result);
+
+        CommandMajorExpense m3 = new CommandMajorExpense("majorexpense");
+        m3.execute(storageManager);
+        String result1 = m3.getInfoCapsule().getOutputStr();
+        assertEquals("These are your receipts above/equal to $" + 100 + "\n"
+                + "1. [transport] 100.0 2019-05-02\n", result1);
     }
 }

--- a/src/test/java/CommandMajorExpenseTest.java
+++ b/src/test/java/CommandMajorExpenseTest.java
@@ -45,5 +45,11 @@ public class CommandMajorExpenseTest {
         String result1 = m3.getInfoCapsule().getOutputStr();
         assertEquals("These are your receipts above/equal to $" + 100 + "\n"
                 + "1. [transport] 100.0 2019-05-02\n", result1);
+
+        CommandMajorExpense m4 = new CommandMajorExpense("majorexpense 34df5");
+        m4.execute(storageManager);
+        String result2 = m4.getInfoCapsule().getOutputStr();
+        assertEquals("Invalid cash input. Please enter integer", result2);
+
     }
 }

--- a/src/test/java/CommandMajorExpenseTest.java
+++ b/src/test/java/CommandMajorExpenseTest.java
@@ -1,0 +1,36 @@
+import executor.command.CommandMajorExpense;
+import org.junit.jupiter.api.Test;
+import storage.StorageManager;
+import ui.Receipt;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.time.LocalDate;
+
+public class CommandMajorExpenseTest {
+    @Test
+    void execute() {
+        StorageManager storageManager = new StorageManager();
+
+        Receipt receiptOne = new Receipt(40.0);
+        receiptOne.addTag("transport");
+        receiptOne.setDate(LocalDate.parse("2019-02-01"));
+        storageManager.getWallet().addReceipt(receiptOne);
+
+        Receipt receiptTwo = new Receipt(4.0);
+        receiptTwo.addTag("food");
+        receiptTwo.setDate(LocalDate.parse("2019-02-02"));
+        storageManager.getWallet().addReceipt(receiptTwo);
+
+
+        CommandMajorExpense m1 = new CommandMajorExpense("majorexpense 40");
+        m1.execute(storageManager);
+        String output = m1.getInfoCapsule().getOutputStr();
+        assertEquals("These are your expenditures above/equal to" + " " + "$" + 40 + "\n"
+                + "1. [transport] 40.0 2019-02-01\n", output);
+        CommandMajorExpense m2 = new CommandMajorExpense("majorexpense -5.0");
+        m2.execute(storageManager);
+        String result = m2.getInfoCapsule().getOutputStr();
+        assertEquals("Input integer must be positive", result);
+    }
+}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/42506891/68522317-fbe35480-02e4-11ea-9a28-8178d35e89db.png)
Given the above list of receipts, 
[majorexpense] will print receipts 4,5,6          (all receipts above/equal to $100) 
[majorexpense] <40> will print receipts 3,4,5,6   (all receipts above/equal to $40)

Handled exceptions and added jUnit tests as well